### PR TITLE
Refactor/상담 API 뷰 및 URL 구조 정리

### DIFF
--- a/backend/consultations/urls.py
+++ b/backend/consultations/urls.py
@@ -1,11 +1,7 @@
-from django.urls import path, include
-from rest_framework.routers import DefaultRouter
-from .views import ConsultationViewSet
-
-# Router 설정: ViewSet을 자동으로 URL에 연결
-router = DefaultRouter()    # ViewSet의 메서드들을 자동으로 URL과 매칭
-router.register('', ConsultationViewSet, basename='consultations')  # ConsultationViewSet 등록
+from django.urls import path
+from .views import ConsultationCreateView, ConsultationLookupView
 
 urlpatterns = [
-    path('', include(router.urls)),     # 자동으로 /, /<id>/ 등의 URL 생성
+    path('', ConsultationCreateView.as_view(), name='consultation-create'),         # as_view() 메서드 호출로 클래스 기반 뷰를 뷰 함수로 변환
+    path('lookup/', ConsultationLookupView.as_view(), name='consultation-lookup'),
 ]


### PR DESCRIPTION
## Related Issue
#13 

## Summary
사용하지 않는 CRUD 기능을 제거하기 위해, 기존 `ViewSet` 기반의 구조를 개별 `APIView`로 리팩토링

## Changes
- **View 구조 개선**: `ConsultationViewSet`을 제거하고, 상담 신청 전용인 `ConsultationCreateView`와 조회 전용인 `ConsultationLookupView`로 분리
 - **불필요한 기능 제거**: 현재 사용하지 않는 `list`, `retrieve`, `update`, `delete` 기능을 삭제하여 백엔드 로직을 경량화
 - **URL 라우팅 명시화**: `DefaultRouter`를 통한 자동 생성 방식 대신 `urls.py`에서 명시적인 `path` 설정을 사용하여 URL 구조를 직접 제어하도록 수정
 - **조회 경로 최적화**: 기존 액션 형태의 조회를 `/lookup/` 경로의 독립적인 POST 뷰로 변경했습니다.
 
## Checklist
- [x] 상담 신청(POST /api/consultations/) 기능 정상 작동 확인
- [x] 상담 조회(POST /api/consultations/lookup/) 기능 정상 작동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 상담 API의 라우팅 구조가 재구성되었습니다.
  * 새로운 `/lookup/` 엔드포인트를 통해 이메일과 비밀번호로 상담 조회 기능이 추가되었습니다.
  * API 엔드포인트의 접근 방식이 간소화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->