### PR TITLE
Feat/Docker Compose 및 Dockerfile에서 경로를 볼륨으로 변경

### DIFF
--- a/docker-compose.nas.yaml
+++ b/docker-compose.nas.yaml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:15-alpine
     volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: aramtax
       POSTGRES_USER: aramtax
@@ -22,9 +22,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     volumes:
-      - ./backend:/app
-      - ./data/media:/app/media
-      - ./data/static:/app/staticfiles
+      - media_volume:/app/media
+      - static_volume:/app/staticfiles
     expose:
       - "8000"
     environment:
@@ -53,17 +52,18 @@ services:
     restart: always
 
   # 3. Frontend (React + Nginx)
+  # 3. Frontend (React + Nginx)
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        NGINX_CONF: nginx.nas.conf
     ports:
       - "3000:80"
     volumes:
-      - ./data/media:/usr/share/nginx/html/media
-      - ./data/static:/usr/share/nginx/html/static
-      # NAS 전용 Nginx 설정 파일 마운트
-      - ./frontend/nginx.nas.conf:/etc/nginx/conf.d/default.conf:ro
+      - media_volume:/usr/share/nginx/html/media
+      - static_volume:/usr/share/nginx/html/static
     environment:
       - VITE_API_URL=https://hwan.cloud
     depends_on:
@@ -78,3 +78,8 @@ services:
     command: tunnel run
     environment:
       - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+
+volumes:
+  postgres_data:
+  media_volume:
+  static_volume:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,9 +12,10 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+ARG NGINX_CONF=nginx.conf
+COPY ${NGINX_CONF} /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"] 
+CMD ["nginx", "-g", "daemon off;"]
 


### PR DESCRIPTION
## Related Issue
#20 

## Summary
데이터 저장 방식을 로컬 호스트 경로 바인딩(Bind Mount)에서 도커 볼륨(Named Volume)으로 변경

## Changes

`docker-compose.nas.yaml`
- postgres, media, static 데이터 경로를 호스트 바인딩(./data/...)에서 도커 볼륨(postgres_data 등)으로 변경
- Frontend 서비스에 NGINX_CONF build argument 추가하여 NAS 전용 설정 파일(nginx.nas.conf) 사용하도록 설정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 및 애플리케이션 파일 저장소를 명명된 볼륨으로 전환하여 배포 안정성을 개선했습니다.
  * 웹 서버 설정을 더 유연하게 구성할 수 있도록 배포 프로세스를 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->