### PR TITLE
Feat/이메일 알림 기능 구현

### DIFF
--- a/backend/consultations/apps.py
+++ b/backend/consultations/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ConsultationsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'consultations'
+
+    def ready(self):
+        import consultations.signals  # signals 등록

--- a/backend/consultations/emails.py
+++ b/backend/consultations/emails.py
@@ -1,0 +1,46 @@
+from django.core.mail import send_mail
+from django.conf import settings
+
+def send_new_consultation_alert(consultation):
+    """ 상담 신청 시 관리자에게 알림 이메일 전송 """
+    subject = f'[새 상담] {consultation.name} - {consultation.get_consultation_type_display()}'
+    message = f"""
+        새로운 상담이 접수되었습니다.
+        이름: {consultation.name}
+        이메일: {consultation.email}
+        연락처: {consultation.phone}
+        상담유형: {consultation.get_consultation_type_display()}
+
+        내용: {consultation.message}
+
+        관리자 페이지에서 확인하세요.
+        """
+
+    send_mail(
+        subject,                        # 제목
+        message,                        # 내용
+        settings.DEFAULT_FROM_EMAIL,    # 보내는 사람
+        [settings.ADMIN_EMAIL]          # 받는 사람
+    )
+
+def send_response_notification(consultation):
+    """ 답변 완료 시 신청자에게 알림 이메일 전송 """
+    subject = f'[세무법인 아람] 상담 답변이 등록되었습니다'
+    message = f"""
+        {consultation.name}님, 안녕하세요.
+
+        요청하신 상담에 대한 답변이 등록되었습니다.
+
+        상담 유형: {consultation.get_consultation_type_display()}
+        답변 내용: {consultation.admin_response}
+
+        감사합니다.
+        세무법인 아람 드림
+        """
+
+    send_mail(
+        subject,                        # 제목
+        message,                        # 내용
+        settings.DEFAULT_FROM_EMAIL,    # 보내는 사람
+        [consultation.email]            # 받는 사람
+    )

--- a/backend/consultations/emails.py
+++ b/backend/consultations/emails.py
@@ -25,7 +25,7 @@ def send_new_consultation_alert(consultation):
 
 def send_response_notification(consultation):
     """ 답변 완료 시 신청자에게 알림 이메일 전송 """
-    subject = f'[세무법인 아람] 상담 답변이 등록되었습니다'
+    subject = '[세무법인 아람] 상담 답변이 등록되었습니다'
     message = f"""
         {consultation.name}님, 안녕하세요.
 

--- a/backend/consultations/models.py
+++ b/backend/consultations/models.py
@@ -77,6 +77,7 @@ class Consultation(models.Model):
         if self.admin_response and self.admin_response != prev_response:
             self.responded_at = timezone.now()
             self.status = 'completed'
+            self._response_changed = True
         # 답변이 삭제된 경우
         elif not self.admin_response:
             self.responded_at = None    # 답변일시 초기화

--- a/backend/consultations/signals.py
+++ b/backend/consultations/signals.py
@@ -9,6 +9,6 @@ def consultation_post_save(sender, instance, created, **kwargs):
         # 새로운 상담 신청 시 관리자에게 알림 이메일 전송
         send_new_consultation_alert(instance)
     else:
-        # 기존 상담에 답변이 추가되었을 때 신청자에게 알림 이메일 전송
-        if instance.admin_response:
+        # 기존 상담에 답변이 새로 추가되거나 변경되었을 때만 알림 이메일 전송
+        if getattr(instance, '_response_changed', False):
             send_response_notification(instance)

--- a/backend/consultations/signals.py
+++ b/backend/consultations/signals.py
@@ -1,0 +1,14 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Consultation
+from .emails import send_new_consultation_alert, send_response_notification
+
+@receiver(post_save, sender=Consultation)
+def consultation_post_save(sender, instance, created, **kwargs):
+    if created:
+        # 새로운 상담 신청 시 관리자에게 알림 이메일 전송
+        send_new_consultation_alert(instance)
+    else:
+        # 기존 상담에 답변이 추가되었을 때 신청자에게 알림 이메일 전송
+        if instance.admin_response:
+            send_response_notification(instance)


### PR DESCRIPTION
## Related Issue
#33 

## Summary
- 새 상담 신청 시 관리자에게 이메일 발송
- 관리자 답변 등록 시 신청자에게 이메일 발송
- Django signals로 처리

## 변경 파일
- `backend/consultations/emails.py` (신규)
- `backend/consultations/signals.py` (신규)
- `backend/consultations/apps.py` (수정)
- `backend/config/settings/base.py` (수정)

## Checklist
- [x] 상담 신청 → 관리자 이메일 수신 확인
- [x] 관리자 답변 등록 → 신청자 이메일 수신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새 상담 접수 시 관리자에게 알림 이메일 자동 발송
  * 상담사 응답 시 신청자에게 통지 이메일 자동 발송
  * 상담 응답 시 상담 상태가 완료로 갱신되고 응답 시각이 기록됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->