### PR TITLE
Infra/Gateway와 서비스 스택 분리

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -12,16 +12,8 @@ services:
       timeout: 5s
       retries: 5
     restart: always
-
-  # Cloudflare Tunnel
-  tunnel:
-    image: cloudflare/cloudflared:latest
-    command: tunnel run
-    env_file:
-      - .env.prod
-    depends_on:
-      - frontend
-    restart: always
+    networks:
+      - internal-net
 
   # Backend
   backend:
@@ -39,6 +31,8 @@ services:
       db-prod:
         condition: service_healthy
     restart: always
+    networks:
+      - internal-net
 
   # Frontend
   frontend:
@@ -53,6 +47,14 @@ services:
     depends_on:
       - backend
     restart: always
+    networks:
+      - internal-net
+      - proxy-net
+
+networks:
+  internal-net:
+  proxy-net:
+    external: true
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Related Issue
#35 

## Summary
Gateway 스택(NPM + Cloudflare Tunnel)과 Aramtax 스택을 분리하여 독립적으로 배포 가능하도록 인프라 구조 변경.

## Changes
- NAS 상에서 게이트웨이 역할을 수행하는 Docker Compose 환경을 구성하여
Nginx Proxy Manager와 Cloudflare Tunnel을 운영

- `docker-compose.prod.yaml`: tunnel 서비스 제거, `proxy-net`(external) / `internal-net` 네트워크 추가
- DB는 `internal-net`에만 연결하여 외부 네트워크에서 격리
- Frontend만 `proxy-net` + `internal-net` 이중 연결 (Gateway ↔ Aramtax 브릿지 역할)
  
## Checklist
- [x] `docker-compose.prod.yaml` 네트워크 설정 완료
- [x] NAS에 Gateway 스택 배포 완료
- [x] NPM Proxy Host 등록 (frontend:80)
- [x] Cloudflare Tunnel URL 변경 (npm:80)
- [x] 전체 트래픽 흐름 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Cloudflare Tunnel 서비스가 제거되었습니다
  * 내부 네트워크 및 프록시 네트워크 구성이 추가되었습니다
  * 백엔드 및 프론트엔드 서비스의 네트워크 아키텍처가 업데이트되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->