### PR TITLE
feat: ECR 이미지 버전 태깅 및 참조 추가

### DIFF
--- a/.github/workflows/deploy-nas.yaml
+++ b/.github/workflows/deploy-nas.yaml
@@ -37,22 +37,26 @@ jobs:
       - name: Build & Push Backend
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build \
             --target prod \
             -t ${ECR_REGISTRY}/${ECR_BACKEND}:latest \
+            -t ${ECR_REGISTRY}/${ECR_BACKEND}:${IMAGE_TAG} \
             ./backend
-          docker push ${ECR_REGISTRY}/${ECR_BACKEND}:latest
+          docker push ${ECR_REGISTRY}/${ECR_BACKEND} --all-tags
 
       - name: Build & Push Frontend
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build \
             --target prod \
             -t ${ECR_REGISTRY}/${ECR_FRONTEND}:latest \
+            -t ${ECR_REGISTRY}/${ECR_FRONTEND}:${IMAGE_TAG} \
             ./frontend
-          docker push ${ECR_REGISTRY}/${ECR_FRONTEND}:latest
+          docker push ${ECR_REGISTRY}/${ECR_FRONTEND} --all-tags
 
   deploy:
     needs: build-and-push
@@ -83,10 +87,12 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           export ECR_REGISTRY=$ECR_REGISTRY
           export ECR_BACKEND=$ECR_BACKEND
           export ECR_FRONTEND=$ECR_FRONTEND
+          export IMAGE_TAG=$IMAGE_TAG
 
           docker compose -f docker-compose.prod.yaml pull
           docker compose -f docker-compose.prod.yaml up -d --remove-orphans

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -17,6 +17,7 @@ services:
 
   # Backend
   backend:
+    image: ${ECR_REGISTRY}/${ECR_BACKEND}:${IMAGE_TAG:-latest}
     build:
       context: ./backend
       target: prod
@@ -36,6 +37,7 @@ services:
 
   # Frontend
   frontend:
+    image: ${ECR_REGISTRY}/${ECR_FRONTEND}:${IMAGE_TAG:-latest}
     build:
       context: ./frontend
       target: prod


### PR DESCRIPTION
## Related Issue

## Summary
기존에 docker-compose.prod.yaml에 `image:` 필드가 없어 ECR 이미지를 실제로 사용하지 않고                             
서버에서 직접 빌드하던 문제를 수정. 이미지에 git sha 태그를 추가해 버전 추적 및                              
롤백이 가능하도록 개선.   

## Changes
- `deploy-nas.yaml`: 빌드 시 `:latest` + `:{git sha}` 태그 동시 부여 및 `--all-tags` 푸시
- `docker-compose.prod.yaml`: backend/frontend에 `image:` 필드 추가로 ECR 이미지 실제 사용

## Checklist
- [x] ECR에 sha 태그 이미지 정상 푸시 확인
- [x] 서버에서 ECR 이미지 pull 후 컨테이너 실행 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 프로세스에 이미지 태그 기반 버전 관리 기능을 추가했습니다. 각 배포에서 특정 버전 태그와 최신 태그를 함께 생성하고, 프로덕션 환경 설정에 버전 정보를 적용하도록 변경했습니다. 이를 통해 배포된 서비스의 버전 추적이 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->